### PR TITLE
Add clustering requirements and fix install command

### DIFF
--- a/projects/Clustering_experiment/requirements.txt
+++ b/projects/Clustering_experiment/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+scikit-learn

--- a/projects/telegram_bot/README.md
+++ b/projects/telegram_bot/README.md
@@ -5,7 +5,7 @@ This is a demo project of a telegram bot
 ## Dependencies
 
 ```
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
 ## Search telegram to test the bot

--- a/projects/whatsapp_Bot/Readme.md
+++ b/projects/whatsapp_Bot/Readme.md
@@ -7,6 +7,6 @@
 # To run app
 - Create virtual Environment
 - Install requirements
-`pip install requirements.txt`
+`pip install -r requirements.txt`
 - run app
 `python main.py`


### PR DESCRIPTION
## Summary
- add requirements for `Clustering_experiment`
- fix incorrect dependency commands in README files

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd33fd17c8329ba43e8af4b9201fe